### PR TITLE
fix --lsbin with mawk-compatible lsbin query

### DIFF
--- a/dlocate
+++ b/dlocate
@@ -478,7 +478,7 @@ else
                 if [ -s "$PLIST" ] ; then
                     "$DLOCATE" -L $PKG | \
                       xargs -d '\n' -r stat -c '%A %n' | \
-                      awk '!/^[^-]/ &&  /^-.{2,8}[xs]/ {print $2}'
+                      awk '/^-..[xs]..[xs]..[xs]/ {print $2}'
                     result=$?
                 else
                     warn "Package $PKG is not installed or $PLIST is empty."


### PR DESCRIPTION
looks like the regex pattern is not supported by `mawk` 1.3.4 which is part of essential bullseye distribution. I updated to use a more primitive regex. 

Mawk manpage doesn't support `{}` chars
```
❯ man mawk |grep -C 3 "special meaning"
       function that expects a regular expression argument.

       AWK  uses  extended  regular  expressions  as with the -E option of grep(1).  The regular expression metacharacters, i.e.,
       those with special meaning in regular expressions are

            \ ^ $ . [ ] | ( ) * + ?
```


## STEPS TO REPEAT
1. Create new schroot with debootstrap `sudo debootstrap bullseye /srv/chroot/test`
1. `dlocate -lsbin bzip2`
2. `dlocate -lsbin ack`

## EXPECTED RESULTS
```
 ./dlocate -lsbin ack
/usr/bin/ack

./dlocate -lsbin bzip2
/bin/bunzip2
/bin/bzcat
/bin/bzdiff
/bin/bzexe
/bin/bzgrep
/bin/bzip2
/bin/bzip2recover
/bin/bzmore
```
## Actual Results
```
❯ dlocate -lsbin ack
[empty]
❯ dlocate -lsbin bzip2
[empty]
```
## Platform Info
```
 cat /etc/debian_version
12.9
```

```
 dpkg -l |grep awk
ii  mawk                                                 1.3.4.20200120-2                 amd64        Pattern scanning and text processing language
```